### PR TITLE
feat - add ssh cd pipeline

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,22 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  SSH:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run scripts in server
+        uses: appleboy/ssh-action@master
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USER }}
+          script: |
+            cd ${{ vars.project_path }}/${{ github.event.repository.name }}
+            git pull


### PR DESCRIPTION
## Overview
- SSH를 활용한 CD 파이프라인 구축
- GCS -> Compute Engine Sync 하려고 했으나 2중 마운트가 안되는 이슈로 우선 ssh로 구현